### PR TITLE
enemy ai

### DIFF
--- a/docs/CLAUDE_ENEMY_UPGRADE_PROPOSAL.md
+++ b/docs/CLAUDE_ENEMY_UPGRADE_PROPOSAL.md
@@ -1,0 +1,202 @@
+# Enemy AI and Pathfinding Upgrade Proposal
+
+## Current State
+Enemies currently move directly toward the player using simple vector movement. This causes issues when obstacles or walls block the path, resulting in enemies getting stuck or exhibiting unnatural behavior.
+
+## Proposed Solutions
+
+### 1. Simple Obstacle Avoidance (Minimal Change)
+Keep direct movement but add basic obstacle detection and avoidance.
+
+**Implementation:**
+- Cast rays left/right when blocked
+- Try alternate angles (±30°, ±60°, ±90°)
+- Move perpendicular to obstacle briefly, then resume direct path
+
+**Pros:**
+- Easy to implement
+- Low CPU cost
+- Minimal code changes
+
+**Cons:**
+- Can get stuck in corners
+- Movement looks robotic
+- Not optimal for complex layouts
+
+### 2. A* Pathfinding (Classic Solution)
+Pre-compute grid of walkable tiles and find optimal paths.
+
+**Implementation:**
+- Divide map into grid cells (16x16 or 32x32)
+- Calculate path from enemy to player using A* algorithm
+- Recalculate periodically (every 0.5-1s) or when blocked
+- Share pathfinding results among nearby enemies for performance
+
+**Pros:**
+- Guaranteed optimal paths
+- Handles mazes and complex layouts well
+- Well-documented algorithm
+
+**Cons:**
+- CPU intensive with many enemies
+- Requires grid setup and maintenance
+- May cause all enemies to take same path
+
+### 3. Flow Fields (Scalable for Hordes)
+Calculate direction vectors for entire map pointing toward player.
+
+**Implementation:**
+- Generate single flow field from player position
+- All enemies just follow local flow direction
+- Update field periodically (every 30-60 frames)
+- Use Dijkstra or brushfire algorithm for field generation
+
+**Pros:**
+- Scales to hundreds of enemies
+- Natural swarming behavior
+- Single calculation for all enemies
+
+**Cons:**
+- Memory overhead for flow field storage
+- Complex implementation
+- Requires careful tuning
+
+### 4. Steering Behaviors (Natural Movement)
+Combine multiple movement impulses for organic motion.
+
+**Behaviors:**
+- **Seek**: Move toward player
+- **Avoid**: Steer around obstacles (using short raycasts)
+- **Separation**: Keep distance from other enemies
+- **Arrival**: Slow down when approaching target
+
+**Implementation:**
+- Weight and blend these forces
+- Use local perception (raycasts) for obstacle detection
+- Smooth movement with acceleration/deceleration
+
+**Pros:**
+- Organic, natural-looking movement
+- Handles dynamic obstacles well
+- No pre-computation needed
+
+**Cons:**
+- Can fail in complex mazes
+- Requires careful force balancing
+- May exhibit emergent unwanted behaviors
+
+### 5. Hybrid Approach (Recommended)
+Combine simple methods based on context and distance.
+
+**Strategy:**
+- **Far from player (>300px)**: Use direct movement with basic avoidance
+- **Medium range (100-300px)**: Use steering behaviors
+- **Close/Complex areas**: Switch to A* if stuck for >2 seconds
+- Cache successful paths between common points
+
+**Pros:**
+- Balances performance and quality
+- Adapts to different scenarios
+- Fallback mechanisms prevent getting stuck
+
+**Cons:**
+- More complex state management
+- Requires tuning thresholds
+- Debugging can be more difficult
+
+### 6. Line-of-Sight with Flanking
+Smarter tactical movement with combat awareness.
+
+**Implementation:**
+- Check LOS to player regularly
+- If blocked, pick flanking positions (left/right of obstacles)
+- Move to intermediate waypoints that have clear paths
+- Some enemies could circle around while others wait
+
+**Pros:**
+- Creates interesting combat scenarios
+- Enemies appear more intelligent
+- Varied attack patterns
+
+**Cons:**
+- Requires tactical analysis of space
+- More complex decision trees
+- May need per-enemy-type behaviors
+
+## Performance Optimizations
+
+Applicable to any chosen approach:
+
+### Time-slicing
+- Spread pathfinding calculations across multiple frames
+- Update different enemy groups on different frames
+
+### Level-of-Detail (LOD) System
+- Distant enemies use simpler AI
+- Off-screen enemies update less frequently
+- Complexity scales with proximity to player
+
+### Path Sharing
+- Groups of enemies going to same destination share calculations
+- Leader calculates path, followers use offset positions
+
+### Path Caching
+- Store recent successful paths
+- Reuse paths when start/end points are similar
+- Invalidate cache when obstacles change
+
+### Update Staggering
+- Don't update all enemies in same frame
+- Use modulo operator with enemy ID for update scheduling
+- Prioritize enemies closer to player
+
+## Implementation Recommendation
+
+Given Shadow Kingdom's characteristics:
+- Real-time combat focus
+- No build dependencies
+- Browser-based performance constraints
+- Current simple architecture
+
+**Recommended approach:**
+
+1. **Phase 1**: Implement Simple Obstacle Avoidance
+   - Quick win with immediate improvement
+   - Minimal code changes
+   - Test performance impact
+
+2. **Phase 2**: Add Steering Behaviors
+   - Layer on top of Phase 1
+   - Improve movement quality
+   - Still relatively simple
+
+3. **Phase 3**: Implement A* Fallback
+   - Only for enemies stuck >2 seconds
+   - Limited grid size around stuck enemy
+   - Cache results aggressively
+
+This phased approach allows incremental improvements while maintaining code simplicity and performance.
+
+## Code Integration Points
+
+Key files that would need modification:
+- `src/systems/step.js`: Main enemy update loop
+- `src/systems/combat.js`: Movement and targeting logic
+- `src/engine/terrain.js`: Obstacle detection interface
+- `src/engine/state.js`: Enemy state management
+
+New files to consider:
+- `src/systems/pathfinding.js`: Core pathfinding algorithms
+- `src/systems/enemy_ai.js`: AI behavior management
+- `src/utils/spatial.js`: Spatial queries and optimizations
+
+## Testing Considerations
+
+- Create test levels with various obstacle configurations
+- Measure performance with different enemy counts
+- Test edge cases: dead ends, narrow passages, moving obstacles
+- Ensure save/load compatibility with new AI states
+
+## Conclusion
+
+The current direct movement approach can be significantly improved without major architectural changes. Starting with simple improvements and progressively adding sophistication allows for maintaining game performance while enhancing enemy behavior. The hybrid approach offers the best balance of simplicity, performance, and player experience.

--- a/docs/CODEX_ENEMY_UPGRADE_PROPOSAL.md
+++ b/docs/CODEX_ENEMY_UPGRADE_PROPOSAL.md
@@ -1,0 +1,179 @@
+#+ CODEX Enemy Upgrade Proposal: Pathfinding & Movement
+
+Status: proposal ready for implementation in phases. Scope focuses on enemy navigation and targeting robustness without heavy refactors.
+
+## Motivation
+Current enemies primarily chase directly with some local steering (hazard avoidance, axis/perpendicular fallback, stuck sign flip). This works in open spaces but struggles at corners, gates, and mazes; it also causes jamming and oscillation when LOS is blocked. We want reliable wall-aware routing that scales to many enemies and plays nicely with new ranged-aware tactics.
+
+## Goals
+- Navigate around blocking obstacles and through chokepoints predictably.
+- Avoid dithering at corners; reduce clumping and jam pressure.
+- Keep CPU cost low (world is ~100×60 tiles) and behavior legible.
+- Layer cleanly with tactical behaviors (cover, zig-zag, juke, dash) without conflicts.
+
+## Overview of Improvements
+1) Local steering upgrades (no global map):
+   - LOS-aware wall-follow with commitment
+   - Obstacle feelers in direction sampling
+   - Corner bias and gate preference
+   - Density-aware spacing
+2) Global guidance via flow-field BFS/Dijkstra (shared for all enemies)
+3) Selective on-demand A* (bosses/featured or when stuck)
+4) Targeting memory and search patterns (last-seen, short search)
+5) Integration order and performance budget
+
+---
+
+## 1) Local Steering Enhancements
+
+### 1.1 LOS-aware wall-follow (commit to a side)
+- When the direct segment to the player intersects a blocking obstacle, choose a side to “hug” (left/right) and commit for 0.6–1.0s rather than re-choosing every frame.
+- Use existing `avoidSign` as default; flip only after a prolonged stuck window (>0.6s with minimal progress).
+- Outcome: smooth cornering instead of oscillation; fewer pile-ups on convex edges.
+
+### 1.2 Obstacle “feelers” in direction sampling
+- Extend the current hazard-based direction sampler with 2–3 short raycasts ahead of the candidate vector (e.g., 1/3, 2/3, 1.0 of a 24–32px probe).
+- Add a high cost if any feeler intersects a blocking obstacle rect. This deprioritizes headings that will immediately collide.
+
+### 1.3 Corner bias around blockers
+- If LOS is blocked, identify the nearest blocking rect along the player ray and compute two corner targets (min/max corners that plausibly route around it).
+- Bias sampled headings toward the corner that reduces distance to the player while respecting feeler costs. Commit briefly (0.6–1.0s) to avoid indecision.
+
+### 1.4 Gate/door preference
+- If a passable “gate” (unlocked) is within ~160px and roughly between the enemy and player, bias toward its center.
+- Treat locked gates as walls.
+
+### 1.5 Density-aware spacing
+- Add a small dynamic penalty proportional to nearby alive enemies within ~20–40px to reduce clumping at chokepoints.
+- Keep collision/axis/perpendicular fallbacks as safety nets; this just lowers jam pressure.
+
+---
+
+## 2) Global Guidance: Flow-Field BFS/Dijkstra
+
+### 2.1 Grid representation
+- Build a tile grid sized `world.tileW × world.tileH` marking walkable vs. blocked.
+- Clearance: enemies are 12×16px; ensure footprint fits by either inflating walls by 1px/using a 2×2 tile clearance test, or checking the full rect per tile move.
+- Optional: hazard weights (mud ×2, fire ×4, lava ×8) to discourage painful paths (Dijkstra), but keep them walkable.
+
+### 2.2 Building the flow field
+- Run a BFS from the player’s tile (or Dijkstra for weighted hazards) to compute a distance field.
+- Update cadence: 4–6 Hz (every ~150–250ms), or on “dirty” events: player moved ≥ 1 tile; obstacles changed; gates lock/unlock; level/theme rebuild; post-load.
+- Memory: 6k tiles → distance array `Uint16Array` (or `Float32Array` for weighted) is trivial.
+
+### 2.3 Using the field per enemy
+- Find the enemy’s tile; pick the neighbor (8-way) with the lowest distance and derive a coarse `pathDir` vector.
+- Blend with local steering (hazards, feelers, density). PathDir gives global intent; steering keeps agents smooth and avoids dynamic collisions.
+- If unreachable (no path / INF distance): fall back to local wander/seek.
+
+### 2.4 Notes
+- Do not include dynamic actors (enemies/player/NPCs) in the grid; handle them via existing collision/resolution.
+- Keep a dirty flag; avoid rebuilding when nothing relevant changed.
+
+---
+
+## 3) Selective On-Demand A*
+
+### 3.1 When to use
+- Only for bosses/featured, or when any enemy has been effectively stuck (>1.0s with minimal displacement) while a path should exist.
+- Also useful for long detours (very large obstacles) where corner bias is insufficient.
+
+### 3.2 How to use
+- Compute a short path to the player or last-seen tile; keep only 2–4 upcoming waypoints.
+- Recompute at most every 0.5–1.0s for that enemy; global cap (e.g., 2–3 A* runs per frame) to avoid spikes.
+- Path smoothing: attempt to skip intermediate waypoints when LOS between current position and later waypoint is clear.
+
+---
+
+## 4) Targeting Memory & Search
+
+### 4.1 Last-seen position
+- Maintain `_lastSeenPlayerTile` while LOS is clear; if LOS breaks, pursue that tile for a short window before reverting to general pursuit/wander.
+
+### 4.2 Search pattern
+- If target not found at last-seen, do a brief local search (e.g., small circle/spiral up to ~1.2s) before fully dropping aggro.
+
+### 4.3 Ranged vs. melee adjustments
+- Ranged enemies: maintain a standoff band (e.g., 90–140px); strafe tangentially within band; close distance when LOS is blocked.
+- Melee: favor shortest path; still benefit from wall-follow/corner bias.
+
+---
+
+## 5) Integration Order (with tactical behaviors)
+
+To avoid conflicts with the ranged-aware tactics (cover, zig-zag, juke, dash):
+
+Priority per frame (highest first):
+1) Dash active → dash vector; suspend other headings (collision still applies).
+2) Juke active → juke vector; suspend path following until juke ends.
+3) Cover commit → bias toward cover corner; peek briefly after LOS regained, then release.
+4) Base heading → prefer flow-field `pathDir`; else direct-to-player `targetDir`.
+5) Zig-zag (if ranged-aware) → blend tangential component into base heading with a short commit.
+6) Local steering → apply hazard costs, obstacle feeler penalties, LOS exposure penalty, and density penalty to finalize heading.
+7) Collision/axis/perpendicular fallbacks and separation.
+
+Notes:
+- Brace affects knockback intake and speed/DR only; it does not set heading, so it layers cleanly.
+- Commit windows (cover/strafe) reduce oscillation; pathDir provides global intent beneath tactics.
+
+---
+
+## 6) Performance Budget
+- Grid: 6k tiles; BFS/Dijkstra at 4–6 Hz is cheap. Use dirty flags to rebuild only when needed.
+- A*: capped invocations per frame; recompute per enemy no more than once per 0.5–1.0s.
+- Direction sampling: keep sample count small (5–7 angles) and early-reject far hazards.
+- LOS checks: reuse existing segment tests; sample a few points (center + corners) as in current code.
+
+---
+
+## 7) Implementation Phases & Acceptance Criteria
+
+Phase 1 — Local Steering Upgrades
+- Add wall-follow commitment, obstacle feelers, corner bias, gate preference, density penalty.
+- Acceptance: enemies round corners without oscillation; fewer jams at chokepoints; no perf regressions.
+
+Phase 2 — Flow Field Guidance
+- Build/update BFS/Dijkstra grid with dirty flags; drive base heading from `pathDir` blended with steering.
+- Acceptance: enemies route around walls reliably; average “stuck” time reduced; CPU steady.
+
+Phase 3 — Selective A*
+- Enable for bosses/featured or stuck cases; add path smoothing; cap per-frame work.
+- Acceptance: bosses/featured recover from maze-like traps; no frame hitches under load.
+
+Phase 4 — Targeting Memory & Search
+- Add last-seen tile + brief search pattern; ensure aggro feels natural.
+- Acceptance: enemies don’t give up immediately when LOS breaks; avoid aimless wandering.
+
+---
+
+## 8) Tunables (initial suggestions)
+- Probe step length: 26–32px; feelers at 0.33/0.66/1.0.
+- Corner commit: 0.6–1.0s.
+- Density penalty radius: 24px; weight small (e.g., 0.2 per neighbor).
+- Flow update cadence: 150–250ms; hazard weights mud×2, fire×4, lava×8.
+- A* caps: ≤3 runs/frame; per-enemy ≥0.6s between runs; path length ≤12 waypoints before smoothing.
+
+---
+
+## 9) Risks & Mitigations
+- Oscillation between tactics/path: use commit timers and priority order; blend, don’t hard switch when possible.
+- Over-avoidance of hazards: keep hazards as costs, not blockers; clamp weights.
+- CPU spikes from A*: cap and stagger; prefer flow field as the default.
+- Corner cases with footprint clearance: validate with inflated walls or 2×2 tile checks.
+
+---
+
+## 10) Debug & Telemetry
+- Toggle overlays (behind `window.DEBUG_ENEMIES`):
+  - Flow field arrows (downhill neighbor)
+  - Current tactic + timers
+  - Cover corner target
+  - Feeler hits and chosen heading
+- Console counters: BFS rebuilds, A* runs/frame, average stuck time.
+
+---
+
+## 11) Compatibility with Ranged-Aware Behaviors
+- This proposal provides the global/base heading and improved local steering. Tactical behaviors (cover, zig-zag, juke, dash, brace) sit above it in priority and temporarily override path following when active.
+- The two plans are complementary: pathfinding gets enemies around the map; tactics make them smarter under fire. The integration order prevents conflicts.
+

--- a/docs/COMPANION_TEMPERAMENT_AND_INTRO_TRIADS.md
+++ b/docs/COMPANION_TEMPERAMENT_AND_INTRO_TRIADS.md
@@ -1,0 +1,167 @@
+# Companion Temperament and VN Intro Triads — Plan
+
+Status: design plan only (no code changes in this doc)
+
+## Goals
+- Define five companion personalities (temperaments) with consistent behavioral hooks.
+- Standardize first‑meet VN “three‑choice” intros per companion with temperament‑driven affinity deltas.
+- Reuse flags and persistence so intros are one‑time and non‑stacking with existing intro boosts.
+- Provide a foundation to extend temperament into dialog, quests, combat barks, and bond gating.
+
+## Temperaments (Five‑Type Model)
+- Nurturing — Warm, reassuring, relationship‑first; forgives soft misreads.
+- Steady — Stoic, dependable, duty/pacing focused; dislikes chaos talk.
+- Playful — Quick, witty, high‑energy; likes banter, dislikes po‑faced seriousness.
+- Practical — Results‑first, unsentimental; values competence and economy, dislikes fluff.
+- Exacting — Intense, perfectionist; rewards crisp alignment, punishes misreads.
+
+### Affinity Profiles (defaults)
+- Nurturing: match +0.3 to +0.4; clash 0; defer 0; bond gate shift −0.3
+- Steady: match +0.3; clash −0.05; defer 0; bond gate shift 0
+- Playful: match +0.3 to +0.5; clash −0.1 (esp. stiff/over‑serious); defer 0; bond gate shift 0
+- Practical: match +0.2 to +0.3; clash −0.1 (frivolous/off‑mission); defer 0; bond gate shift +0.2
+- Exacting: match +0.2 to +0.4 (up to +0.6 for special beats); clash −0.15; defer 0; bond gate shift +0.5
+
+Notes
+- Clash penalties never block recruitment; they only set a spikier starting point.
+- Affinity remains clamped in [1, 10]; bond gate shift applies only where a node does not set explicit affinity min.
+
+## Companion → Temperament Mapping
+- Nurturing: Canopy, Hola, Urn, Snek
+- Steady: Nellis, Oyin
+- Playful: Tin, Cowsill, Twil
+- Practical: Varabella
+- Exacting: Yorna, Fana
+
+## First‑Meet VN “Triads” (per companion)
+Each first‑sight VN presents three choices:
+- Match (aligned with intro; recruits; grants affinity by temperament/override)
+- Clash (respectful but off‑tone; recruits; grants 0 or negative by temperament/override)
+- Defer (short denial; no affinity change; marks intro seen; recruitment remains via normal talk)
+
+Implementation notes
+- Use `introTexts[<key>]` for VN text body.
+- Reuse existing intro reward flags (below) to prevent double‑granting between VN and talk intros.
+- Set `<name>_intro_deferred` on Defer for analytics/banter gates.
+
+### Per‑Character Triads (lines + deltas)
+- Canopy (Nurturing) — +0.3 / 0
+  - Match: “Let’s find your sister—walk with me.”
+  - Clash: “I could use another pair of fighting hands—join up.”
+  - Defer: “We’ll talk later, Canopy.”
+
+- Yorna (Exacting) — +0.2 / −0.15
+  - Match: “We take the key, drop Vast—fall in.”
+  - Clash: “Hang back and patch me up, alright?”
+  - Defer: “Not now, Yorna.”
+
+- Hola (Nurturing) — +0.3 / 0
+  - Match: “Stay close; call the breeze—we’ll get the key.”
+  - Clash: “Frontline with me—we need a brawler.”
+  - Defer: “Another time, Hola.”
+
+- Oyin (Steady) — +0.3 / −0.05
+  - Match: “Walk with me—learn as we go.”
+  - Clash: “I need a seasoned striker right now.”
+  - Defer: “Let’s talk later, Oyin.”
+
+- Twil (Playful) — +0.3 / −0.1
+  - Match: “Read the ground and call the lanes—join me.”
+  - Clash: “Skip the scouting—we just need brute force.”
+  - Defer: “Not now, Twil.”
+
+- Tin (Playful) — +0.3 / 0
+  - Match: “Set the beat—keep our hands moving.”
+  - Clash: “We need slow and steady, not fast.”
+  - Defer: “Later, Tin.”
+
+- Nellis (Steady) — +0.3 / −0.1
+  - Match: “Keep the line; I’ll lead—you hold.”
+  - Clash: “I’m chasing speed and chaos today.”
+  - Defer: “Hold that thought, Nellis.”
+
+- Urn (Nurturing) — +0.4 / 0
+  - Match: “Let’s lift the streets—walk with me.”
+  - Clash: “I need a hard hitter, not a cheer.”
+  - Defer: “We’ll come back to this, Urn.”
+
+- Varabella (Practical) — +0.4 (override) / −0.15
+  - Match: “I want sharp eyes—call angles and cover.”
+  - Clash: “Save the angles; just swing hard.”
+  - Defer: “Later, Varabella.”
+
+- Cowsill (Playful/Steady lean) — +0.3 / −0.05
+  - Match: “Be my strike partner—let’s double every hit.”
+  - Clash: “We actually need a healer more than damage.”
+  - Defer: “Another time, Cowsill.”
+
+- Fana (Exacting) — +0.6 / −0.1
+  - Match: “You’re free—burn what clings. Walk with me.”
+  - Clash: “We need cold precision, not heat.”
+  - Defer: “Rest first, Fana.”
+
+- Snek (Nurturing lite) — +0.2 / 0
+  - Match: “Coil close and slow our foes.”
+  - Clash: “I was hoping for… thumbs.”
+  - Defer: “Curl up for now, Snek.”
+
+## Flags & Persistence
+- VN seen: managed via existing VN system (`runtime.vnSeen[id]`).
+- Defer flag: `<name>_intro_deferred` set on the Defer option.
+- One‑time affinity flags (reused to prevent double‑grants):
+  - canopy_intro_encourage
+  - yorna_intro_encourage
+  - hola_intro_encourage
+  - oyin_intro_encourage
+  - twil_intro_encourage
+  - tin_intro_encourage
+  - nellis_intro_encourage
+  - urn_intro_encourage
+  - varabella_intro_respect
+  - cowsill_intro_team
+  - fana_intro_reassure
+  - snake_intro_encourage (new, reserved)
+
+## Data Model (proposed; no code in this doc)
+- `temperamentByCompanion`: `{ canopy: 'nurturing', yorna: 'exacting', ... }`
+- `temperamentProfiles`: per‑type defaults `{ match, clash, defer, gateShift }` with optional ranges for later dialog beats.
+- `introOptions`: per‑companion `{ match: { label, delta, flag }, clash: { label, delta }, defer: { label } }` for VN triads.
+- Dialog extensions (future): allow choices to carry `tone: 'match'|'clash'` so the renderer infers deltas from temperament when `affinity_add` is omitted.
+
+## Integration Plan (when implementing)
+1) Content data
+   - Add `temperamentByCompanion` and `temperamentProfiles` (new small data file).
+   - Add `introOptions` entries using the lines and deltas above.
+2) VN intro
+   - On spawn for each recruitable NPC, attach `vnOnSight` with `tree` composed from `introTexts[<key>]` + `introOptions[<key>]` (Match/Clash/Defer wiring).
+   - Match/Clash apply `affinity_add` with the specified delta and a once‑flag prior to `join_party`.
+   - Defer sets `<name>_intro_deferred` and `end`.
+3) Flags/persistence
+   - Reuse existing intro once‑flags; add `snake_intro_encourage` only.
+   - Ensure `vnSeen` and transient intro state persist/clear per current VN system.
+4) Later dialog (optional next phase)
+   - Support `tone` in choice nodes; if present and no explicit `affinity_add`, apply temperament defaults.
+   - Allow scene overrides for special beats (e.g., Fana +0.6 moments).
+5) Bond gating (optional)
+   - Apply `gateShift` when node min is not explicitly set (gentle −, exacting +).
+
+## Cross‑System Hooks (future)
+- Barks/banter: temperament‑specific lines on Match/Clash; e.g., Exacting snaps, Nurturing reassures.
+- Quest framing: Nurturing leans protect/aid; Practical prefers concise strike/utility; Playful likes tempo/fun; Steady holds lines; Exacting surgical challenges.
+- Combat tuning (optional): unlock strongest trigger variants earlier (Nurturing/Playful), later (Exacting), neutral (Steady/Practical).
+- Synergy hints: temperament pairs can unlock small banter or micro‑affinity moments.
+
+## QA Checklist (when shipping)
+- First‑sight VN appears once per companion; cool‑down respected; seen flags persist.
+- Party full replacement flow works from Match/Clash recruit.
+- Defer closes VN, sets `<name>_intro_deferred`, leaves normal talk intro intact.
+- Affinity deltas apply once; flags prevent double‑granting with talk intros.
+- Negative affinity never blocks recruitment; values clamp to [1,10].
+- Mobile/touch selection works; number keys map correctly; audio cues sane.
+
+## Open Questions
+- Finalize exact clash penalties for Steady/Playful (−0.05 vs −0.1) per character.
+- Keep Varabella’s +0.4 override under Practical, or normalize to +0.3?
+- Apply bond gate shifts globally by temperament, or only for specific bond nodes?
+- Localizations: confirm brevity targets for triad labels (< ~60 chars) across languages.
+

--- a/docs/ENEMY_AI_PATHFINDING_AND_RANGED_BEHAVIOR.md
+++ b/docs/ENEMY_AI_PATHFINDING_AND_RANGED_BEHAVIOR.md
@@ -1,0 +1,135 @@
+# Enemy AI: Pathfinding + Ranged-Aware Behaviors
+
+Status: design approved for bosses/featured; mooks unchanged. This document consolidates movement/pathfinding upgrades with ranged-aware counterplay and defines how they interact without conflict.
+
+## Goals
+- Enemies navigate around walls/obstacles reliably without expensive per-enemy A*.
+- Bosses/featured feel smarter under ranged fire: break LOS, strafe, resist stunlock, occasionally close distance.
+- Preserve fairness and readability: short commitments, visible telegraphing, modest randomness.
+
+## Scope and Roles
+- Applies to: Bosses and Featured foes (including key guardians).
+- Excluded: Mooks (retain current simple chase/wander + local hazard steering).
+- Ranged enemies: additionally maintain standoff range and strafe.
+
+## Ranged Awareness (when active)
+Active if either:
+- Player has a ranged weapon equipped with ammo, or
+- Player fired within the last 0.8s.
+
+Deactivates after ~1.2s without shots or if the player is within melee range (< 40px).
+
+## Behavior Matrix
+- Bosses: zig-zag advance, use cover (LOS breaking), brace on hit, juke on shot, gap-closer dash (telegraphed).
+- Featured/Guardians: same behaviors with slightly longer cooldowns/shorter durations/lower multipliers.
+- Mooks: none of the above; keep existing behavior.
+
+## Behavior Specs (no code)
+
+### 1) Zig-Zag Advance (commit to lateral strafe)
+- While ranged-aware and 60–220px away, blend a perpendicular component into the approach.
+- Commit to a chosen strafe side for a short window, then re-evaluate. Use existing `avoidSign` as default side; store `_strafeSign` if needed.
+- Purpose: reduce straight-line knockback loops and make arrows miss more often.
+
+Defaults:
+- Boss: tangential weight ~0.55; commit 0.8s.
+- Featured: tangential weight ~0.40; commit 0.6s.
+
+### 2) Use Cover (LOS breaking everywhere)
+- If LOS to the player is clear and distance > 80px, score nearby blocking obstacles (within ~160px). Choose a corner that both reduces LOS exposure and reduces distance to player.
+- Commit to moving toward the cover target for 0.8–1.0s. If LOS becomes blocked en route, continue until commit ends; then peek around the corner briefly (0.3–0.35s), then re-evaluate.
+- Integrate into the direction sampler by adding a penalty for candidate directions that maintain strong LOS to the player beyond 80px.
+
+### 3) Brace on Hit (anti-stunlock window; strong)
+- When hit by a player projectile, start a short “brace” window that reduces knockback taken and adds temporary projectile DR. Refreshable by new hits; no stacking beyond caps.
+- Also reduce speed modestly during brace to signal state (readability) without removing threat.
+
+Defaults:
+- Boss: 0.9s, knockback ×0.30, +2 projectile DR, speed ×0.85.
+- Featured: 0.75s, knockback ×0.40, +1.5 projectile DR, speed ×0.9.
+
+### 4) Juke on Shot (sidestep incoming projectile)
+- When a new player projectile is on a near-collision course within ~120px (simple dot/time test), roll a chance to sidestep perpendicular for a brief burst. Cooldown prevents spam.
+
+Defaults:
+- Boss: 22% chance, 1.0s cooldown, 0.28s duration at ×1.35 speed.
+- Featured: 12% chance, 1.4s cooldown, 0.22s duration at ×1.25 speed.
+
+### 5) Gap-Closer Dash (break kiting; telegraphed)
+- Conditions: distance 90–180px, LOS clear, not bracing/juking, on cooldown. Telegraph with a brief pre-dash pause/slow so it’s readable, then dash with heavy knockback resistance.
+
+Defaults:
+- Boss: 6.5s ±1.5s cooldown; 0.18s pre-telegraph; 0.45s at ×2.8 speed; knockback ×0.20 during dash.
+- Featured: 11s ±2.0s cooldown; 0.16s pre-telegraph; 0.35s at ×2.2 speed; knockback ×0.35 during dash.
+
+### 6) Ranged Enemies: Standoff + Strafe
+- Maintain an ideal range band (e.g., 90–140px). When inside band with LOS, strafe tangentially; advance if LOS is blocked; retreat slightly if too close. Shares the same zig-zag/cover/juke rules as above where relevant.
+
+## Pathfinding Plan (global, simple, fast)
+
+### Flow Field (BFS/Dijkstra) Grid
+- Build a walkable/blocked grid at tile resolution (use `world.tileW × world.tileH`).
+- Run one BFS (or Dijkstra if hazard weighting is enabled) from the player’s tile to compute a distance field. Update at 4–6 Hz (every 150–250ms) or when “dirty”.
+- Dirty triggers: player moved ≥ 1 tile; obstacles added/removed or gates lock/unlock; level/theme changes; after load.
+- Walkable definition respects enemy footprint (12×16px): ensure the entire rect fits in walkable cells (inflate walls or validate 2×2 tile footprint as needed).
+- Hazard weighting (optional): mud cost ×2, fire ×4, lava ×8 to bias routes around pain without forbidding them.
+
+### Using the Flow Field
+- For each enemy, look at its current tile and pick the neighbor with the lowest distance (8-way preferred) to form a coarse `pathDir` vector.
+- Do not include dynamic actors (player/enemies/NPCs) in the grid; handle those via collision and local steering already present.
+- If unreachable (INF): fall back to current wander/seek logic.
+
+### Optional Targeted A*
+- Only for bosses/featured when an enemy has been stuck > 1s, compute a short path to the player’s current or last-seen tile; keep 2–4 waypoints; recompute at most every 0.5–1.0s; global cap on runs per frame to avoid spikes.
+
+## Integration & Priority (avoid conflicts)
+
+Movement vector synthesis per enemy each frame (highest priority first):
+1) Dash: if `_dashTimer > 0`, movement is dash vector; ignore other influences except collision.
+2) Juke: if `_jukeTimer > 0`, movement is perpendicular juke vector.
+3) Cover Commit: if `_coverTarget` active and `_tacticTimer > 0`, bias toward cover corner (overrides pathDir/targetDir); peek briefly when LOS regained, then clear.
+4) Base Heading: prefer `pathDir` from flow field when available; otherwise direct-to-player (`targetDir`).
+5) Zig-Zag: when ranged-aware and in band, blend tangential component with weight (boss 0.55, featured 0.40) and commit window.
+6) Local Steering: run existing sampler (hazard cost + obstacle feelers + LOS exposure penalty) to choose best nearby direction; apply brace speed/knockback modifiers.
+7) Collision/Separation: keep current axis/perpendicular fallbacks and entity separation; flip `avoidSign` on prolonged stuck.
+
+Notes:
+- Brace modifies knockback intake and speed/DR only; it does not force a heading and therefore does not fight pathDir/steering.
+- Cover and Zig-Zag operate on top of pathDir (coarse guidance) and are time-committed to reduce oscillation.
+- Juke/Dash temporarily suspend path-following to prevent jitter.
+
+## State per Enemy (runtime fields)
+- `_braceTimer`: seconds remaining of brace (knockback reduction, temp projectile DR, speed mult).
+- `_jukeCd`, `_jukeTimer`: cooldown and active timer for juke sidestep.
+- `_dashCd`, `_dashTelegraph`, `_dashTimer`: gap-closer cadence, telegraph, and active duration timers.
+- `_tacticTimer`: commitment window for current tactic (strafe side, cover target).
+- `_strafeSign`: chosen strafe side (defaults to `avoidSign` when unset).
+- `_coverTarget`: pixel coordinates of chosen cover corner (null when inactive).
+- `_lastSeenPlayerTile`: last tile with clear LOS to player (for brief persistence when LOS breaks).
+
+## Implementation Phases
+1) Phase 1 (low risk, big win): Zig-Zag Advance + Brace on Hit (boss/featured only).
+2) Phase 2: Juke on Shot + LOS-based Cover scoring/commit (add LOS exposure penalty to sampler).
+3) Phase 3: Gap-Closer Dash with pre-dash telegraph (boss and featured; numbers above).
+4) Phase 4: Flow Field pathfinding grid (BFS/Dijkstra), updated 4–6 Hz; integrate as base heading.
+5) Phase 5 (optional): Targeted A* for bosses/featured when stuck >1s, capped.
+
+## Tuning Defaults (initial)
+- See per-behavior defaults above. All values are centralizable for easy runtime tweaking (e.g., a `AI_TUNING` map keyed by class).
+
+## Performance & Debugging
+- Grid size: 100×60 = 6k tiles; BFS/Dijkstra 4–6 Hz is cheap. Keep a dirty flag to avoid unnecessary rebuilds.
+- Keep cover search local (<=160px) and use simple corner candidates.
+- Add `window.DEBUG_ENEMIES` overlays for: flow field arrows, current tactic, cover target, dash telegraph window.
+
+## Fairness Considerations
+- Telegraph dash (0.16–0.18s pre-pause), cap juke chance, and keep brace brief. If the player stops firing, effects decay quickly.
+- Ranged enemies should prefer standoff/strafe over blind rush, but still commit if LOS is blocked.
+
+## Open Questions
+- Exact hazard weights in Dijkstra (mud/fire/lava) and whether to keep them global or per-level.
+- Ideal standoff band for specific ranged enemies.
+- Whether to visually indicate brace state (e.g., brief tint) for clarity (optional).
+
+This plan intentionally layers a global, cheap pathfinding signal (flow field) beneath local steering and tactical behaviors (cover, zig-zag, juke, dash). Priority rules ensure tactics temporarily override the path signal without fighting it, avoiding oscillation and keeping behaviors legible.
+

--- a/docs/GEMINI_ENEMY_AI_UPGRADE.md
+++ b/docs/GEMINI_ENEMY_AI_UPGRADE.md
@@ -1,0 +1,61 @@
+# Gemini Enemy AI Upgrade Plan
+
+This document outlines the concepts and potential solutions for upgrading the enemy AI in the game, moving from a simple direct-pathing system to a more robust and intelligent one.
+
+### 1. The Problem: Greedy Pathing
+
+*   **Current State:** Enemies are using a "greedy" algorithm. At every moment, they make the locally optimal choice (move closer to the player) without any foresight.
+*   **Why it Fails:** This is easily defeated by any concave obstacle. An enemy will run into the corner of a 'U' shaped wall and get stuck, even if the entrance is two steps to their left.
+
+### 2. Simple Improvements (Good, but still flawed)
+
+Before we get to full pathfinding, there are some simpler, "good enough" hacks.
+
+*   **"Bug" or "Wall Follower" AI:** This is a classic simple solution.
+    *   **How it works:** If the enemy runs into a wall, it picks a direction (e.g., left) and "hugs" the wall, following its contour until it's no longer blocked and can move toward the player again.
+    *   **Pros:** Very simple to implement. You just need a "blocked" state and a "follow wall" state. It can solve surprisingly complex mazes.
+    *   **Cons:** It's inefficient. The enemy might go the long way around an obstacle. It can also get trapped in certain geometric shapes (like a spiral). It looks very robotic.
+
+### 3. The "Real" Solution: A* (A-Star) Pathfinding
+
+This is the industry-standard solution for this problem and almost certainly the right approach for your game.
+
+*   **The Concept:** A* is an algorithm that intelligently finds the shortest path between two points on a graph. In a 2D game, your "graph" is a grid of tiles representing the level.
+*   **How it Works (High Level):**
+    1.  **Grid Representation:** First, you need to represent your game level as a grid. Each cell is either "walkable" or "unwalkable" (a wall/obstacle). Your `level4_city_walls.js` and `temple_dungeon_map_190x110.png` suggest you already have the data to build this.
+    2.  **The Search:** A* starts at the enemy's position and explores walkable neighbor tiles, calculating two costs for each tile:
+        *   `g-cost`: The actual cost of the path from the start tile to the current tile.
+        *   `h-cost` (Heuristic): An *estimated* cost to get from the current tile to the player's tile. This is usually the straight-line distance, ignoring obstacles.
+    3.  **The Magic (`f-cost`):** A* combines these (`f-cost = g-cost + h-cost`) to prioritize which tiles to explore next. It always chooses the path that seems most promising, which allows it to "look ahead" and avoid dead ends without exhaustively searching every possible path.
+*   **The Result:** The algorithm returns an optimal list of tiles (a path) that the enemy can simply walk along to reach the player, navigating perfectly around any obstacle.
+*   **Pros:**
+    *   **Optimal and Correct:** It finds the shortest path (given a good heuristic).
+    *   **Flexible:** It can handle changing environments; you just update the grid's "walkable" status.
+    *   **Looks Intelligent:** Enemies will appear much smarter as they navigate complex environments purposefully.
+*   **Cons:**
+    *   **Implementation Complexity:** It's more complex than direct movement. You'll need a data structure (like a Priority Queue) and to implement the algorithm's logic.
+    *   **Performance:** It can be computationally expensive if your levels are huge or if many enemies are pathfinding at the exact same time. However, for a game like this, it's almost always manageable with optimizations.
+
+### 4. Beyond Movement: Enhancing AI Behavior
+
+Once you have A* pathfinding, you can build more interesting behaviors on top of it.
+
+*   **Line of Sight (LOS):** An enemy shouldn't know where the player is at all times. You can use a line-drawing algorithm (like Bresenham's) to check if there's an unobstructed line between the enemy and the player.
+    *   If no LOS: The enemy could be `IDLE` or `PATROLLING` between waypoints.
+    *   If LOS is gained: The enemy switches to a `PURSUE` state and generates an A* path to the player's *last known position*.
+    *   If LOS is lost: The enemy might go to the player's last seen spot and then enter a `SEARCHING` state before giving up and returning to `PATROL`.
+*   **State Machines:** This is the key to organizing AI. An enemy isn't just "moving"; it's in a specific *state*.
+    *   **Example States:** `IDLE`, `PATROL`, `PURSUE`, `ATTACKING`, `FLEEING`.
+    *   The AI logic is then just a set of rules for transitioning between these states. (e.g., "If in `PURSUE` state and distance to player < attack range, switch to `ATTACKING` state.").
+*   **Targeting:** Who do they attack?
+    *   Right now, it's just the player.
+    *   With companions in the game (`companion_dialogs.js`), you could introduce more complex targeting: attack the closest character, attack the character who last damaged them (aggro), etc.
+
+### Recommended Path Forward
+
+1.  **Grid Representation:** Your first step would be to create a system that can represent your level geometry as a simple 2D grid of walkable/unwalkable nodes.
+2.  **A* Implementation:** Find a good JavaScript library for A* pathfinding (there are many) or implement it yourself. It's a fantastic learning exercise.
+3.  **Integrate:** Create a basic `PURSUE` state for your enemies. When they want to chase the player, they will:
+    a. Request a path from the A* system from their current position to the player's position.
+    b. Receive a list of coordinates.
+    c. Walk from one coordinate to the next until they reach the end or need a new path.

--- a/src/data/ai_tuning.js
+++ b/src/data/ai_tuning.js
@@ -21,6 +21,9 @@ export const AI_TUNING = {
     cover:  { commitSec: 1.0 },
     dash:   { telegraphSec: 0.18, durationSec: 0.45, speedMul: 2.8, kbMul: 0.15, cooldownBaseSec: 6.5, cooldownJitterSec: 1.5 },
     advance:{ triggerHits: 2, windowSec: 0.8, durationSec: 0.7, speedMul: 1.5, kbMul: 0.12, dashCooldownCapSec: 4.5 },
+    // Pursuit/steering
+    engageDistPx: 240, // clamp pursuit steering within this distance
+    steering: { hazardWeightMul: 0.6, obstaclePenaltyMul: 0.6 },
   },
   featured: {
     zigzag: { weight: 0.40, commitSec: 0.6 },
@@ -29,6 +32,8 @@ export const AI_TUNING = {
     cover:  { commitSec: 0.8 },
     dash:   { telegraphSec: 0.16, durationSec: 0.35, speedMul: 2.2, kbMul: 0.20, cooldownBaseSec: 9.0, cooldownJitterSec: 1.5 },
     advance:{ triggerHits: 2, windowSec: 0.8, durationSec: 0.6, speedMul: 1.35, kbMul: 0.20, dashCooldownCapSec: 5.0 },
+    engageDistPx: 200,
+    steering: { hazardWeightMul: 0.8, obstaclePenaltyMul: 0.85 },
   },
   mook: {
     zigzag: { weight: 0.0, commitSec: 0.0 },

--- a/src/data/ai_tuning.js
+++ b/src/data/ai_tuning.js
@@ -1,0 +1,39 @@
+// Centralized AI tuning values for quick iteration.
+// Edit in console via window.AI_TUNING (exposed in main.js).
+
+export const AI_TUNING = {
+  global: {
+    // Player ranged detection
+    rangedAwareRecentSec: 0.8,
+    // Zig-zag activation band
+    zigzag: { minDist: 60, maxDist: 220 },
+    // Cover behavior
+    cover: { searchRadius: 160, minDist: 80, maxDist: 260, cooldown: 0.6 },
+    // Juke detection thresholds
+    juke: { scanMax: 24, nearAheadPx: 120, lateralPadPx: 6 },
+    // Dash activation band
+    dash: { minDist: 90, maxDist: 180 },
+  },
+  boss: {
+    zigzag: { weight: 0.55, commitSec: 0.8 },
+    brace:  { durationSec: 0.9, kbMul: 0.30, speedMul: 0.85, projDr: 2 },
+    juke:   { chance: 0.22, cooldownSec: 1.0, durationSec: 0.28, speedMul: 1.35 },
+    cover:  { commitSec: 1.0 },
+    dash:   { telegraphSec: 0.18, durationSec: 0.45, speedMul: 2.8, kbMul: 0.20, cooldownBaseSec: 6.5, cooldownJitterSec: 1.5 },
+  },
+  featured: {
+    zigzag: { weight: 0.40, commitSec: 0.6 },
+    brace:  { durationSec: 0.75, kbMul: 0.40, speedMul: 0.90, projDr: 1.5 },
+    juke:   { chance: 0.12, cooldownSec: 1.4, durationSec: 0.22, speedMul: 1.25 },
+    cover:  { commitSec: 0.8 },
+    dash:   { telegraphSec: 0.16, durationSec: 0.35, speedMul: 2.2, kbMul: 0.35, cooldownBaseSec: 11.0, cooldownJitterSec: 2.0 },
+  },
+  mook: {
+    zigzag: { weight: 0.0, commitSec: 0.0 },
+    brace:  { durationSec: 0.0, kbMul: 1.0, speedMul: 1.0, projDr: 0 },
+    juke:   { chance: 0.0, cooldownSec: 0.0, durationSec: 0.0, speedMul: 1.0 },
+    cover:  { commitSec: 0.0 },
+    dash:   { telegraphSec: 0.0, durationSec: 0.0, speedMul: 1.0, kbMul: 1.0, cooldownBaseSec: 0.0, cooldownJitterSec: 0.0 },
+  },
+};
+

--- a/src/data/ai_tuning.js
+++ b/src/data/ai_tuning.js
@@ -24,6 +24,7 @@ export const AI_TUNING = {
     // Pursuit/steering
     engageDistPx: 240, // clamp pursuit steering within this distance
     steering: { hazardWeightMul: 0.6, obstaclePenaltyMul: 0.6 },
+    baseSpeedMul: 1.20,
     // Telegraph timings (visual wind-up before the attack fires)
     melee: { telegraphSec: 0.18 },
     ranged: { telegraphSec: 0.16 },
@@ -37,6 +38,7 @@ export const AI_TUNING = {
     advance:{ triggerHits: 2, windowSec: 0.8, durationSec: 0.6, speedMul: 1.35, kbMul: 0.20, dashCooldownCapSec: 5.0 },
     engageDistPx: 200,
     steering: { hazardWeightMul: 0.8, obstaclePenaltyMul: 0.85 },
+    baseSpeedMul: 1.15,
   },
   mook: {
     zigzag: { weight: 0.0, commitSec: 0.0 },

--- a/src/data/ai_tuning.js
+++ b/src/data/ai_tuning.js
@@ -28,6 +28,8 @@ export const AI_TUNING = {
     // Telegraph timings (visual wind-up before the attack fires)
     melee: { telegraphSec: 0.18 },
     ranged: { telegraphSec: 0.16 },
+    // Flow/path blending
+    path: { flowWeight: 0.35, minDot: -0.1 },
   },
   featured: {
     zigzag: { weight: 0.40, commitSec: 0.6 },
@@ -39,6 +41,8 @@ export const AI_TUNING = {
     engageDistPx: 200,
     steering: { hazardWeightMul: 0.8, obstaclePenaltyMul: 0.85 },
     baseSpeedMul: 1.15,
+    // Flow/path blending
+    path: { flowWeight: 0.45, minDot: -0.2 },
   },
   mook: {
     zigzag: { weight: 0.0, commitSec: 0.0 },

--- a/src/data/ai_tuning.js
+++ b/src/data/ai_tuning.js
@@ -24,6 +24,9 @@ export const AI_TUNING = {
     // Pursuit/steering
     engageDistPx: 240, // clamp pursuit steering within this distance
     steering: { hazardWeightMul: 0.6, obstaclePenaltyMul: 0.6 },
+    // Telegraph timings (visual wind-up before the attack fires)
+    melee: { telegraphSec: 0.18 },
+    ranged: { telegraphSec: 0.16 },
   },
   featured: {
     zigzag: { weight: 0.40, commitSec: 0.6 },

--- a/src/data/ai_tuning.js
+++ b/src/data/ai_tuning.js
@@ -19,14 +19,16 @@ export const AI_TUNING = {
     brace:  { durationSec: 0.9, kbMul: 0.30, speedMul: 0.85, projDr: 2 },
     juke:   { chance: 0.22, cooldownSec: 1.0, durationSec: 0.28, speedMul: 1.35 },
     cover:  { commitSec: 1.0 },
-    dash:   { telegraphSec: 0.18, durationSec: 0.45, speedMul: 2.8, kbMul: 0.20, cooldownBaseSec: 6.5, cooldownJitterSec: 1.5 },
+    dash:   { telegraphSec: 0.18, durationSec: 0.45, speedMul: 2.8, kbMul: 0.15, cooldownBaseSec: 6.5, cooldownJitterSec: 1.5 },
+    advance:{ triggerHits: 2, windowSec: 0.8, durationSec: 0.7, speedMul: 1.5, kbMul: 0.12, dashCooldownCapSec: 4.5 },
   },
   featured: {
     zigzag: { weight: 0.40, commitSec: 0.6 },
     brace:  { durationSec: 0.75, kbMul: 0.40, speedMul: 0.90, projDr: 1.5 },
-    juke:   { chance: 0.12, cooldownSec: 1.4, durationSec: 0.22, speedMul: 1.25 },
+    juke:   { chance: 0.16, cooldownSec: 1.2, durationSec: 0.22, speedMul: 1.25 },
     cover:  { commitSec: 0.8 },
-    dash:   { telegraphSec: 0.16, durationSec: 0.35, speedMul: 2.2, kbMul: 0.35, cooldownBaseSec: 11.0, cooldownJitterSec: 2.0 },
+    dash:   { telegraphSec: 0.16, durationSec: 0.35, speedMul: 2.2, kbMul: 0.20, cooldownBaseSec: 9.0, cooldownJitterSec: 1.5 },
+    advance:{ triggerHits: 2, windowSec: 0.8, durationSec: 0.6, speedMul: 1.35, kbMul: 0.20, dashCooldownCapSec: 5.0 },
   },
   mook: {
     zigzag: { weight: 0.0, commitSec: 0.0 },
@@ -36,4 +38,3 @@ export const AI_TUNING = {
     dash:   { telegraphSec: 0.0, durationSec: 0.0, speedMul: 1.0, kbMul: 1.0, cooldownBaseSec: 0.0, cooldownJitterSec: 0.0 },
   },
 };
-

--- a/src/engine/audio.js
+++ b/src/engine/audio.js
@@ -39,6 +39,7 @@ const files = {
     keepLine: 'assets/audio/sfx/keepLine.wav',
     quake: 'assets/audio/sfx/quake.wav',
     hiss: 'assets/audio/sfx/hiss.wav',
+    bossTelegraph: 'assets/audio/sfx/telegraph.wav',
   },
 };
 

--- a/src/engine/dialog.js
+++ b/src/engine/dialog.js
@@ -142,6 +142,7 @@ export function startDebugMenu() {
     { label: 'Lighting: Ambient 4 (Dim)', action: 'light_ambient', data: 4 },
     { label: 'Lighting: Ambient 8 (Bright)', action: 'light_ambient', data: 8 },
     { label: 'Give Torches x3', action: 'debug_give_torches' },
+    { label: 'Give Arrows x50', action: 'debug_give_arrows' },
     { label: `God Mode: ${runtime.godMode ? 'On' : 'Off'}`, action: 'toggle_godmode' },
     { label: `Snake Mode: ${runtime.snakeMode ? 'On' : 'Off'}`, action: 'toggle_snake_mode' },
     { label: 'Back', action: 'end' },
@@ -397,6 +398,18 @@ export function selectChoice(index) {
         const S = await import('./state.js');
         S.addItemToInventory(player.inventory, { id: 'torch', name: 'Torch', slot: 'leftHand', stackable: true, maxQty: 99, qty: 3 });
         showBanner('Added 3 Torches');
+      } catch {}
+      startDebugMenu();
+    })();
+    return;
+  }
+  if (choice.action === 'debug_give_arrows') {
+    (async () => {
+      try {
+        const S = await import('./state.js');
+        // Add 50 arrows across stacks (max 25/stack)
+        S.addItemToInventory(player.inventory, { id: 'arrow_basic', name: 'Arrows', slot: 'misc', stackable: true, maxQty: 25, qty: 50 });
+        showBanner('Added 50 Arrows');
       } catch {}
       startDebugMenu();
     })();

--- a/src/engine/pathfinding.js
+++ b/src/engine/pathfinding.js
@@ -1,0 +1,120 @@
+import { runtime, world, player, obstacles } from './state.js';
+import { TILE } from './constants.js';
+
+const INF = 0xffff;
+
+function ensureFlowStruct() {
+  if (!runtime._flow) runtime._flow = { dist: null, w: 0, h: 0, lastBuildAt: 0, lastPlayerTx: -1, lastPlayerTy: -1, dirty: true };
+  return runtime._flow;
+}
+
+function buildBlockedGrid() {
+  const w = world.tileW|0, h = world.tileH|0;
+  const blocked = new Uint8Array(w * h);
+  // Mark any obstacle that blocks movement (mirrors moveWithCollision logic)
+  for (const o of obstacles) {
+    if (!o) continue;
+    if (o.type === 'gate' && o.locked === false) continue; // opened gates do not block
+    // Non-blocking types
+    if (o.type === 'chest' || o.type === 'mud' || o.type === 'fire' || o.type === 'lava') continue;
+    const x1 = Math.max(0, Math.floor(o.x / TILE));
+    const y1 = Math.max(0, Math.floor(o.y / TILE));
+    const x2 = Math.min(w - 1, Math.floor((o.x + o.w - 1) / TILE));
+    const y2 = Math.min(h - 1, Math.floor((o.y + o.h - 1) / TILE));
+    for (let ty = y1; ty <= y2; ty++) {
+      for (let tx = x1; tx <= x2; tx++) {
+        blocked[ty * w + tx] = 1;
+      }
+    }
+  }
+  return blocked;
+}
+
+function bfsFromPlayer(blocked) {
+  const w = world.tileW|0, h = world.tileH|0;
+  const dist = new Uint16Array(w * h);
+  dist.fill(INF);
+  const sx = Math.max(0, Math.min(w - 1, Math.floor(player.x / TILE)));
+  const sy = Math.max(0, Math.min(h - 1, Math.floor(player.y / TILE)));
+  const si = sy * w + sx;
+  if (blocked[si]) return dist; // player tile blocked — leave INF (shouldn't happen)
+  const qx = new Int16Array(w * h);
+  const qy = new Int16Array(w * h);
+  let head = 0, tail = 0;
+  qx[tail] = sx; qy[tail] = sy; tail++;
+  dist[si] = 0;
+  // 8 neighbors; prevent diagonal corner cutting
+  const dirs = [
+    [-1, 0], [1, 0], [0, -1], [0, 1],
+    [-1,-1], [1,-1], [-1,1], [1,1]
+  ];
+  while (head !== tail) {
+    const x = qx[head], y = qy[head]; head++;
+    const d = dist[y * w + x] + 1;
+    for (let k = 0; k < dirs.length; k++) {
+      const nx = x + dirs[k][0];
+      const ny = y + dirs[k][1];
+      if (nx < 0 || ny < 0 || nx >= w || ny >= h) continue;
+      const ni = ny * w + nx;
+      if (blocked[ni]) continue;
+      // Prevent cutting diagonally through corners
+      if (dirs[k][0] !== 0 && dirs[k][1] !== 0) {
+        const ax = x + dirs[k][0], ay = y; // horizontal neighbor
+        const bx = x, by = y + dirs[k][1]; // vertical neighbor
+        if (ax < 0 || ay < 0 || ax >= w || ay >= h) continue;
+        if (bx < 0 || by < 0 || bx >= w || by >= h) continue;
+        if (blocked[ay * w + ax] && blocked[by * w + bx]) continue;
+      }
+      if (dist[ni] !== INF) continue;
+      dist[ni] = d;
+      qx[tail] = nx; qy[tail] = ny; tail++;
+    }
+  }
+  return dist;
+}
+
+export function rebuildFlowField(throttleMs = 200) {
+  try {
+    const flow = ensureFlowStruct();
+    const now = (performance && performance.now) ? performance.now() : Date.now();
+    const w = world.tileW|0, h = world.tileH|0;
+    const ptx = Math.max(0, Math.min(w - 1, Math.floor(player.x / TILE)));
+    const pty = Math.max(0, Math.min(h - 1, Math.floor(player.y / TILE)));
+    const movedTile = (ptx !== flow.lastPlayerTx || pty !== flow.lastPlayerTy);
+    if (!flow.dirty && !movedTile && (now - (flow.lastBuildAt || 0)) < throttleMs) return;
+    const blocked = buildBlockedGrid();
+    const dist = bfsFromPlayer(blocked);
+    flow.dist = dist; flow.w = w; flow.h = h; flow.lastBuildAt = now; flow.lastPlayerTx = ptx; flow.lastPlayerTy = pty; flow.dirty = false;
+  } catch {}
+}
+
+export function sampleFlowDirAt(px, py) {
+  try {
+    const flow = runtime._flow; if (!flow || !flow.dist) return null;
+    const w = flow.w|0, h = flow.h|0;
+    const tx = Math.max(0, Math.min(w - 1, Math.floor(px / TILE)));
+    const ty = Math.max(0, Math.min(h - 1, Math.floor(py / TILE)));
+    const di = ty * w + tx;
+    const d = flow.dist[di];
+    if (d === INF || d === 0) return null; // unreachable or already at player tile
+    let best = { d: d, nx: tx, ny: ty };
+    for (let oy = -1; oy <= 1; oy++) {
+      for (let ox = -1; ox <= 1; ox++) {
+        if (ox === 0 && oy === 0) continue;
+        const nx = tx + ox, ny = ty + oy;
+        if (nx < 0 || ny < 0 || nx >= w || ny >= h) continue;
+        const nd = flow.dist[ny * w + nx];
+        if (nd < best.d) best = { d: nd, nx, ny };
+      }
+    }
+    if (best.nx === tx && best.ny === ty) return null;
+    const vx = best.nx - tx, vy = best.ny - ty;
+    const len = Math.hypot(vx, vy) || 1;
+    return { x: vx / len, y: vy / len };
+  } catch { return null; }
+}
+
+export function markFlowDirty() {
+  try { ensureFlowStruct().dirty = true; } catch {}
+}
+

--- a/src/engine/render.js
+++ b/src/engine/render.js
@@ -412,6 +412,31 @@ export function render(terrainBitmap, obstacles) {
       ctx.restore();
     }
     // Boss marker removed; keep glow only
+    // Debug tactics overlay
+    try {
+      if (window && (window.DEBUG_TACTICS || window.DEBUG_ENEMIES)) {
+        const sx = Math.round(e.x + e.w/2 - camera.x);
+        const sy = Math.round(e.y - 14 - camera.y);
+        ctx.save();
+        ctx.font = '9px monospace';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'bottom';
+        ctx.fillStyle = '#eaeaea';
+        const tags = [];
+        if (e._dashTelegraph && e._dashTelegraph > 0) tags.push(`Dash*${e._dashTelegraph.toFixed(2)}`);
+        else if (e._dashTimer && e._dashTimer > 0) tags.push(`Dash ${e._dashTimer.toFixed(2)}`);
+        if (e._jukeTimer && e._jukeTimer > 0) tags.push(`Juke ${e._jukeTimer.toFixed(2)}`);
+        if (e._coverTimer && e._coverTimer > 0) tags.push(`Cover ${e._coverTimer.toFixed(2)}`);
+        if (e._braceTimer && e._braceTimer > 0) tags.push(`Brace ${e._braceTimer.toFixed(2)}`);
+        if (e._advanceTimer && e._advanceTimer > 0) tags.push(`Advance ${e._advanceTimer.toFixed(2)}`);
+        if (tags.length) {
+          const txt = tags.join(' | ');
+          ctx.strokeStyle = '#000'; ctx.lineWidth = 3; ctx.strokeText(txt, sx, sy);
+          ctx.fillText(txt, sx, sy);
+        }
+        ctx.restore();
+      }
+    } catch {}
   }
 
   // Lighting overlay: coarse, tile-based darkness over world only (not UI)

--- a/src/engine/state.js
+++ b/src/engine/state.js
@@ -566,6 +566,8 @@ export const runtime = {
     _h: 0,
     nodes: [], // invisible light nodes: { x, y, level?, radius?, enabled? }
   },
+  // Pathfinding flow field (coarse, tile-based)
+  _flow: { dist: null, w: 0, h: 0, lastBuildAt: 0, lastPlayerTx: -1, lastPlayerTy: -1, dirty: true },
 
 };
 

--- a/src/main.js
+++ b/src/main.js
@@ -14,6 +14,7 @@ import { updatePartyUI, fadeTransition, updateQuestHint, exitChat, showLevelTitl
 import { applyPendingRestore } from './engine/save_core.js';
 import { loadGame, getSaveMeta } from './engine/save.js';
 import { loadLevel1, loadLevel2, loadLevel3, loadLevel4, loadLevel5, loadLevel6, LEVEL_LOADERS } from './engine/levels.js';
+import { AI_TUNING } from './data/ai_tuning.js';
 
 // Initial level: use loader registry (Level 1 by default)
 let terrain = loadLevel1();
@@ -174,6 +175,30 @@ try {
       return found;
     }
     return null;
+  };
+  // Expose AI tuning for quick iteration from console
+  window.AI_TUNING = AI_TUNING;
+  window.setAITuning = function(kind, path, value) {
+    try {
+      const k = String(kind || '').toLowerCase();
+      const obj = (AI_TUNING[k] || AI_TUNING.global);
+      const parts = String(path || '').split('.').filter(Boolean);
+      let ref = (parts[0] === 'global') ? AI_TUNING.global : obj;
+      if (parts[0] === 'global') parts.shift();
+      for (let i = 0; i < parts.length - 1; i++) { const p = parts[i]; if (!(p in ref)) ref[p] = {}; ref = ref[p]; }
+      ref[parts[parts.length - 1]] = value;
+      return true;
+    } catch (e) { console.warn('setAITuning failed', e); return false; }
+  };
+  window.giveArrows = async (qty = 50) => {
+    try {
+      const S = await import('./engine/state.js');
+      const U = await import('./engine/ui.js');
+      const n = Math.max(1, Math.floor(Number(qty || 50)));
+      S.addItemToInventory(player.inventory, { id: 'arrow_basic', name: 'Arrows', slot: 'misc', stackable: true, maxQty: 25, qty: n });
+      U.showBanner && U.showBanner(`Added ${n} Arrows`);
+      return n;
+    } catch (e) { try { console.warn('giveArrows failed:', e); } catch {} return 0; }
   };
 } catch {}
 

--- a/src/systems/combat.js
+++ b/src/systems/combat.js
@@ -7,6 +7,7 @@ import { enterChat } from '../engine/ui.js';
 import { startDialog, startPrompt } from '../engine/dialog.js';
 import { BREAKABLE_LOOT, CHEST_LOOT, CHEST_LOOT_L2, CHEST_LOOT_L3, rollFromTable, itemById } from '../data/loot.js';
 import { spawnProjectile } from '../engine/state.js';
+import { markFlowDirty } from '../engine/pathfinding.js';
 
 export function startAttack() {
   const now = performance.now() / 1000;
@@ -365,6 +366,7 @@ function tryUnlockGate(hb) {
       const baseMsg = `Used ${itm.name || 'Key'} to open ${gateName}`;
       const msg = matched ? (clearSuffix ? `${baseMsg} — ${clearSuffix}` : `${baseMsg} — Quest updated`) : baseMsg;
       showBanner(msg);
+      try { markFlowDirty(); } catch {}
       // Consume the item if configured
       if (shouldConsume) {
         try {

--- a/src/systems/combat.js
+++ b/src/systems/combat.js
@@ -90,6 +90,7 @@ export function handleAttacks(dt) {
         const idx = obstacles.indexOf(o);
         if (idx !== -1) obstacles.splice(idx, 1);
         playSfx('break');
+        try { import('../engine/pathfinding.js').then(m => m.markFlowDirty && m.markFlowDirty()).catch(()=>{}); } catch {}
       }
     }
     const hasOyin = companions.some(c => (c.name || '').toLowerCase().includes('oyin'));

--- a/src/systems/step.js
+++ b/src/systems/step.js
@@ -309,6 +309,7 @@ export function step(dt) {
               const idx = obstacles.indexOf(o);
               if (idx !== -1) obstacles.splice(idx, 1);
               try { playSfx('break'); } catch {}
+              try { import('../engine/pathfinding.js').then(m => m.markFlowDirty && m.markFlowDirty()).catch(()=>{}); } catch {}
             }
             // Consume the projectile unless it pierces
             if (p.pierce > 0) { p.pierce--; }

--- a/src/systems/step.js
+++ b/src/systems/step.js
@@ -1199,7 +1199,10 @@ export function step(dt) {
       const dashTeleMul = (e._dashTelegraph && e._dashTelegraph > 0) ? 0.4 : 1; // slow slightly during telegraph
       const dashMult = ((e._dashTimer && e._dashTimer > 0) && (!e._dashTelegraph || e._dashTelegraph <= 0)) ? (e._dashSpeedMult || 1) : 1;
       const advMult = (e._advanceTimer && e._advanceTimer > 0) ? (e._advanceSpeedMul || 1) : 1;
-      const spdMul = spdBoost * Math.max(jukeMult, dashMult) * dashTeleMul * advMult;
+      // Base class speed multiplier (tunable via AI_TUNING)
+      const role = String(e.kind||'mook').toLowerCase();
+      const baseClassMul = (AI_TUNING[role]?.baseSpeedMul) || 1;
+      const spdMul = spdBoost * Math.max(jukeMult, dashMult) * dashTeleMul * advMult * baseClassMul;
       moveWithCollision(e, best.x * e.speed * spdMul * mul * dt, best.y * e.speed * spdMul * mul * dt, solidsForEnemy);
       let moved = Math.hypot(e.x - oldX, e.y - oldY);
       // Axis fallback if stuck

--- a/src/systems/step.js
+++ b/src/systems/step.js
@@ -1259,6 +1259,7 @@ export function step(dt) {
                 // Start telegraph and cache aim
                 e._shootAim = Math.atan2(py2 - ey, px2 - ex);
                 e._shootTele = (AI_TUNING.boss?.ranged?.telegraphSec) || 0.14;
+                try { playSfx('bossTelegraph'); } catch {}
                 // Do not fire this frame; fire after telegraph expires
               } else {
                 // Waiting for telegraph to finish; skip firing
@@ -1350,6 +1351,7 @@ export function step(dt) {
           e._meleeTele = Math.max(0, (e._meleeTele || 0) - dt);
           if ((e._meleeTele || 0) <= 0 && player.invulnTimer <= 0) {
             e._meleeTele = (AI_TUNING.boss?.melee?.telegraphSec) || 0.18;
+            try { playSfx('bossTelegraph'); } catch {}
             // Delay actual damage until telegraph expires
             continue;
           }


### PR DESCRIPTION
- **AI: Phase 1-3 ranged-aware behaviors (brace/zigzag/juke/cover/dash) + central AI_TUNING + flow-field pathfinding grid (BFS) with throttle + debug arrow give option + clean HP potion banner**
- **Fix: remove top-level await in non-async contexts; use dynamic import with .then() to mark flow field dirty when breakables destroyed**
- **AI: Anti-stunlock improvements — reduce projectile knockback vs elites; scale KB by brace/advance; faster knockback decay while braced/advancing; debug tactics overlay**
- **AI tuning + steering fixes: expose engageDistPx and steering weights; faster flow rebuild; LOS-first pursuit clamp; cover seeks only after recent hits and avoids away-from-player moves; boss music radius widened; player sprite visibility safety reset**
- **Boss telegraphs: add melee/ranged telegraph timing and visuals; subtle filled ring + sprite wiggle during telegraph; ranged telegraph aim line; tuning knobs in AI_TUNING**
- **Boss attack telegraph SFX: add 'bossTelegraph' sfx and play on melee/ranged telegraph start; subtle telegraph visuals and sprite wiggle already in place**
- **Speed tuning: add baseSpeedMul for bosses/featured in AI_TUNING (boss 1.20, featured 1.15) and apply per-frame; supports live tweaking via setAITuning**
- **Pathfinding reliability: blend flow direction with direct chase using AI_TUNING path.flowWeight + minDot; gate wall-follow to only when stuck and LOS blocked; add path tunables for boss/featured**
